### PR TITLE
docs: add pre-built agents section (Codebase QnA, CodeGen, Debugging)

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -65,6 +65,14 @@
             "pages": [
               "agents/api-access",
               {
+                "group": "Pre-built Agents",
+                "pages": [
+                  "pre-built-agents/codebase-qna-agent",
+                  "pre-built-agents/codegen-agent",
+                  "pre-built-agents/debugging-agent"
+                ]
+              },
+              {
                 "group": "Custom Agents",
                 "pages": [
                   "custom-agents/introduction",

--- a/pre-built-agents/codebase-qna-agent.mdx
+++ b/pre-built-agents/codebase-qna-agent.mdx
@@ -1,0 +1,143 @@
+---
+title: 'Codebase Q&A Agent'
+description: 'Answer any question about your codebase through semantic search and knowledge graph traversal.'
+---
+
+The Codebase Q&A Agent answers questions about your codebase using semantic search and knowledge graph traversal. It locates relevant code, analyzes relationships, and provides comprehensive answers with precise citations.
+
+<CardGroup cols={2}>
+  <Card title="Semantic Search" icon="magnifying-glass" href="#how-it-works">
+    Find code by meaning, not just text
+  </Card>
+  <Card title="19 Specialized Tools" icon="wrench" href="#available-tools">
+    Knowledge graph and code analysis
+  </Card>
+  <Card title="Multi-Agent Mode" icon="users" href="#how-it-works">
+    Q&A Specialist sub-agent for complex queries
+  </Card>
+  <Card title="Precise Citations" icon="quote-left" href="#api-overview">
+    File paths and line numbers in every answer
+  </Card>
+</CardGroup>
+
+## Overview
+
+The Codebase Q&A Agent answers natural language questions about your codebase. It navigates the knowledge graph, fetches relevant files, and synthesizes findings into structured markdown responses with exact file and line citations.
+
+Use it to:
+- Locate where specific features or functions live
+- Understand how components interact
+- Trace data flows end-to-end
+- Explore architecture and design patterns
+- Onboard to unfamiliar codebases quickly
+
+## API Overview
+
+**Authentication:** Bearer token required
+
+### Create a Conversation
+
+```bash cURL
+curl -X POST https://production-api.potpie.ai/api/v1/conversations/ \
+  -H "Authorization: Bearer <token>" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "user_id": "user_123",
+    "title": "Understanding Authentication",
+    "status": "active",
+    "project_ids": ["proj_abc123"],
+    "agent_ids": ["codebase_qna_agent"]
+  }'
+```
+
+### Send a Question
+
+```bash cURL
+curl -X POST "https://production-api.potpie.ai/api/v1/conversations/{conversation_id}/message/?stream=false" \
+  -H "Authorization: Bearer <token>" \
+  -F "content=Where is authentication implemented?"
+```
+
+### Request Format
+
+```typescript
+// Conversation creation
+{
+  user_id: string
+  title: string
+  status: "active"
+  project_ids: string[]
+  agent_ids: ["codebase_qna_agent"]
+}
+
+// Message (Form data — multipart/form-data)
+{
+  content: string            // Your question about the codebase
+  node_ids?: string          // Optional: JSON string of NodeContext[]
+  images?: File[]            // Optional: image attachments
+}
+```
+
+### Response Format
+
+```typescript
+{
+  response: string           // Markdown-formatted answer with citations
+  tool_calls: ToolCall[]     // Tools invoked during exploration
+  citations: string[]        // Files and line numbers referenced
+}
+```
+
+## How It Works
+
+The agent enriches context before processing — loading referenced node IDs and fetching the project file structure. It then uses the knowledge graph to locate relevant code semantically, analyze component relationships, and synthesize findings into a structured response.
+
+For complex queries requiring synthesis across many files, the agent automatically activates **multi-agent mode**, delegating to a Q&A Specialist sub-agent (up to 12 iterations).
+
+## Common Use Cases
+
+<AccordionGroup>
+  <Accordion title="Find where a feature is implemented" icon="crosshairs" defaultOpen={true}>
+    ```
+    "Where is authentication implemented?"
+    "Show me the complete payment flow from cart to order confirmation"
+    "List all API endpoints related to user management"
+    ```
+  </Accordion>
+  <Accordion title="Understand how something works" icon="book-open">
+    ```
+    "How does authentication work in this app?"
+    "Trace what happens when a user submits a form"
+    "What happens when a background job fails?"
+    ```
+  </Accordion>
+  <Accordion title="Explore architecture and dependencies" icon="diagram-project">
+    ```
+    "What design patterns are used in this codebase?"
+    "What does the UserService depend on?"
+    "Which services interact with the database directly?"
+    ```
+  </Accordion>
+</AccordionGroup>
+
+<Tip>
+  Ask follow-up questions in the same conversation — the agent maintains context across the full conversation thread using the same `conversation_id`.
+</Tip>
+
+## Available Tools
+
+| Category | Tools |
+|----------|-------|
+| **Knowledge Graph** | `ask_knowledge_graph_queries`, `get_code_from_multiple_node_ids`, `get_node_neighbours_from_node_id`, `get_code_from_probable_node_name`, `get_nodes_from_tags` |
+| **Code Navigation** | `get_code_file_structure`, `fetch_file`, `fetch_files_batch`, `analyze_code_structure`, `bash_command` |
+| **Research** | `web_search_tool`, `webpage_extractor` |
+| **Task Tracking** | `read_todos`, `write_todos`, `add_todo`, `update_todo_status`, `remove_todo`, `add_subtask`, `set_dependency`, `get_available_tasks`, `add_requirements`, `get_requirements` |
+
+<Note>
+  During project indexing (`INFERRING` status), embedding-dependent tools are temporarily excluded.
+</Note>
+
+## Related Agents
+
+- [CodeGen Agent](/pre-built-agents/codegen-agent) — generates and applies code changes after exploration
+- [Debugging Agent](/pre-built-agents/debugging-agent) — systematic bug diagnosis and root cause analysis

--- a/pre-built-agents/codegen-agent.mdx
+++ b/pre-built-agents/codegen-agent.mdx
@@ -1,0 +1,176 @@
+---
+title: 'CodeGen Agent'
+description: 'Generate production-ready code modifications with diff views and comprehensive dependency analysis.'
+---
+
+The CodeGen Agent generates production-ready code modifications through systematic codebase analysis. It tracks changes using a session-based system, provides diff views for review, and can push changes directly to your repository via pull request.
+
+<CardGroup cols={2}>
+  <Card title="Session-Based Changes" icon="layer-group" href="#api-overview">
+    Redis-backed tracking across multiple files
+  </Card>
+  <Card title="Diff Views" icon="code-compare" href="#reviewing-changes">
+    Review exact changes before applying
+  </Card>
+  <Card title="Multi-Agent Mode" icon="users" href="#how-it-works">
+    Code Implementation sub-agent (20 iterations)
+  </Card>
+  <Card title="PR Creation" icon="code-branch" href="#reviewing-changes">
+    Push changes directly to your repository
+  </Card>
+</CardGroup>
+
+## Overview
+
+The CodeGen Agent takes your natural language request and generates the necessary code across all relevant files. It analyzes your existing patterns, matches your project's style, and tracks all changes in a reviewable session before anything is applied.
+
+Use it to:
+- Add new features and endpoints
+- Modify existing code with style-matched changes
+- Fix bugs with root cause explanations
+- Refactor code while preserving functionality
+
+## API Overview
+
+**Authentication:** Bearer token required
+
+### Create a Conversation
+
+```bash cURL
+curl -X POST https://production-api.potpie.ai/api/v1/conversations/ \
+  -H "Authorization: Bearer <token>" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "user_id": "user_123",
+    "title": "Add user profile endpoint",
+    "status": "active",
+    "project_ids": ["proj_abc123"],
+    "agent_ids": ["code_generation_agent"]
+  }'
+```
+
+### Send a Code Request
+
+```bash cURL
+curl -X POST "https://production-api.potpie.ai/api/v1/conversations/{conversation_id}/message/?stream=false" \
+  -H "Authorization: Bearer <token>" \
+  -F "content=Add a GET /api/users/:id endpoint that returns user details"
+```
+
+### Request Format
+
+```typescript
+// Conversation creation
+{
+  user_id: string
+  title: string
+  status: "active"
+  project_ids: string[]
+  agent_ids: ["code_generation_agent"]
+}
+
+// Message (Form data — multipart/form-data)
+{
+  content: string            // Your code modification request
+  node_ids?: string          // Optional: JSON string of NodeContext[]
+}
+```
+
+### Response Format
+
+```typescript
+{
+  response: string           // Markdown explanation of changes made
+  tool_calls: ToolCall[]     // Tools used during generation
+  citations: string[]        // Files referenced during generation
+}
+```
+
+## How It Works
+
+1. **Context Enrichment** — Fetches code from referenced node IDs to understand existing patterns
+2. **Systematic Analysis** — Identifies all files impacted by the requested change
+3. **Pattern Examination** — Examines existing code conventions and style
+4. **Style-Matched Generation** — Generates changes that match your project exactly
+
+All modifications are tracked in a session. You can review diffs before applying any changes to your repository.
+
+### Multi-Agent Mode
+
+For complex code generation tasks, the agent delegates to a **Code Implementation sub-agent** with up to **20 iterations** — the highest among all agents. Integration agents handle framework-specific code generation.
+
+## Common Use Cases
+
+<AccordionGroup>
+  <Accordion title="Adding new features" icon="plus" defaultOpen={true}>
+    ```
+    "Add user profile endpoint to the API"
+    "Implement email notifications for password resets"
+    "Create a dashboard component with charts"
+    ```
+    The agent generates all required new and modified files, tracks them in the session, and shows you diffs before anything is applied.
+  </Accordion>
+  <Accordion title="Modifying existing code" icon="pen-to-square">
+    ```
+    "Update the login function to support OAuth"
+    "Add error handling to the payment processor"
+    "Refactor the user service to use async/await"
+    ```
+    The agent locates relevant files, makes precise changes, and shows diffs for each modification.
+  </Accordion>
+  <Accordion title="Fixing bugs" icon="bug">
+    ```
+    "Fix the null pointer error in checkout"
+    "Resolve the race condition in data sync"
+    "Correct the SQL injection vulnerability in search"
+    ```
+    The agent provides both the fix and an explanation of the root cause, and may suggest additional improvements.
+  </Accordion>
+</AccordionGroup>
+
+## Reviewing Changes
+
+Before applying changes, you can inspect everything in the session.
+
+### View All Changes
+
+```bash cURL
+curl -X POST "https://production-api.potpie.ai/api/v1/conversations/{conversation_id}/message/?stream=false" \
+  -H "Authorization: Bearer <token>" \
+  -F "content=Show me all changes in the current session"
+```
+
+### View Specific File Diff
+
+```bash cURL
+curl -X POST "https://production-api.potpie.ai/api/v1/conversations/{conversation_id}/message/?stream=false" \
+  -H "Authorization: Bearer <token>" \
+  -F "content=Show me the diff for app/routes/users.py"
+```
+
+### Export Changes
+
+```bash cURL
+curl -X POST "https://production-api.potpie.ai/api/v1/conversations/{conversation_id}/message/?stream=false" \
+  -H "Authorization: Bearer <token>" \
+  -F "content=Export all changes"
+```
+
+## Available Tools
+
+| Category | Tools |
+|----------|-------|
+| **Knowledge Graph** | `ask_knowledge_graph_queries`, `get_code_from_multiple_node_ids`, `get_node_neighbours_from_node_id`, `get_code_from_probable_node_name`, `get_nodes_from_tags` |
+| **Code Navigation** | `get_code_file_structure`, `fetch_file`, `fetch_files_batch`, `analyze_code_structure`, `bash_command` |
+| **Code Changes** | `create_file`, `update_file`, `delete_file`, `get_code_changes`, `get_file_diff` |
+| **Research** | `web_search_tool`, `webpage_extractor` |
+| **Task Tracking** | `read_todos`, `write_todos`, `add_todo`, `update_todo_status`, `remove_todo`, `add_subtask`, `set_dependency`, `get_available_tasks`, `add_requirements`, `get_requirements` |
+
+<Note>
+  During project indexing (`INFERRING` status), embedding-dependent tools are temporarily excluded.
+</Note>
+
+## Related Agents
+
+- [Codebase Q&A Agent](/pre-built-agents/codebase-qna-agent) — answers questions about your codebase before making changes
+- [Debugging Agent](/pre-built-agents/debugging-agent) — systematic bug diagnosis and root cause analysis

--- a/pre-built-agents/debugging-agent.mdx
+++ b/pre-built-agents/debugging-agent.mdx
@@ -1,0 +1,121 @@
+---
+title: 'Debugging Agent'
+description: 'Systematic bug diagnosis and resolution through root cause analysis and generalization.'
+---
+
+The Debugging Agent provides systematic bug diagnosis and resolution. It follows an 8-step debugging methodology for complex issues and adapts its approach based on context, staying conversational for general questions and switching to a rigorous structured mode for actual bugs.
+
+<CardGroup cols={2}>
+  <Card title="8-Step Methodology" icon="list-ol" href="#debugging-methodology">
+    Structured root cause analysis
+  </Card>
+  <Card title="Dual-Mode Behavior" icon="shuffle" href="#dual-mode-behavior">
+    Conversational or methodical, based on context
+  </Card>
+  <Card title="17 Tools" icon="wrench" href="#available-tools">
+    Knowledge graph and code analysis
+  </Card>
+  <Card title="Multi-Agent Mode" icon="users" href="#multi-agent-mode">
+    Debug Solution Specialist sub-agent
+  </Card>
+</CardGroup>
+
+## Pre-Implementation Checklist
+
+Before implementation, the agent verifies all of the following:
+
+- Generalized issue documented
+- Addresses root cause not symptom
+- All components covered
+- Fix location justified
+- Completeness checked
+- Knowledge not spreading
+- Future callers get the fix
+
+The Debugging Agent has two operating modes activated automatically based on the incoming query:
+
+| Mode | Triggered By | Behavior |
+|------|-------------|----------|
+| **Conversational** | Questions, explanations, code exploration | Natural dialogue, build on context, thorough but flexible |
+| **Debugging** | Bug reports, unexpected behavior, fix requests | Strict 8-step methodology, explicit step announcements, requirements and todo tracking |
+
+## Dual-Mode Behavior
+
+### Conversational Mode
+
+For general questions and code exploration, the agent:
+- Navigates the codebase using knowledge graph tools
+- Provides cited, markdown-formatted responses
+- Adapts to user expertise level
+- Builds on previous context in the conversation
+
+### Debugging Mode
+
+Triggered when the query involves a bug report, an error, unexpected behavior, or a fix request. The agent announces each step explicitly, maintains a requirements list, and tracks progress via todos throughout.
+
+
+## Debugging Methodology
+
+The agent follows a strict 8-step process. **Steps cannot be skipped.**
+
+<Steps>
+  <Step title="Understand and Validate the Problem">
+    The agent separates the problem from any suggested fix in the query. Users see symptoms, not root causes. The agent finds the real issue independently. It documents the problem via `add_requirements` and breaks exploration into trackable tasks with `add_todo`.
+  </Step>
+
+  <Step title="Explore and Hypothesize">
+    Formulates hypotheses about root causes and adds each as a verification task via `add_todo`. Updates task status with `update_todo_status` as each hypothesis is verified.
+  </Step>
+
+  <Step title="Identify Root Cause">
+    The agent traces the complete code flow, both upstream and downstream. Before concluding code is missing, it checks whether the logic exists but is not working correctly. Must produce an explicit statement: ROOT CAUSE IDENTIFIED with an exact description.
+  </Step>
+
+  <Step title="Generalize the Issue">
+    This step is always required. The agent identifies the general pattern the bug represents, what else is affected, and what the design-level fix should be.
+  </Step>
+
+  <Step title="Design Solution">
+    The agent looks for existing patterns before writing any code and validates the fix location to ensure it addresses the root cause rather than the symptom.
+  </Step>
+
+  <Step title="Scrutinize and Refine">
+    Challenges the solution with null, empty, zero, and boundary inputs. Verifies the fix covers all affected components and calls `get_requirements` to confirm all requirements are addressed.
+  </Step>
+
+  <Step title="Implement">
+    Makes precise, surgical changes. For debugging tasks, typically explains the fix and provides guidance rather than applying changes directly.
+  </Step>
+
+  <Step title="Final Verification">
+    Calls `get_requirements` to verify all issues are addressed. Calls `read_todos` to ensure all exploration tasks are completed. Confirms the fix addresses the generalized pattern, not just the original symptom.
+  </Step>
+</Steps>
+
+
+## Multi-Agent Mode
+
+For complex debugging tasks, the agent activates multi-agent mode:
+
+- **Main Agent:** coordinates investigation and applies the debugging methodology
+- **Debug Solution Specialist:** generates debugging solutions and strategies
+- **Integration Agents:** handle framework-specific analysis
+
+## API Overview
+
+See the <a href="/api-reference/overview" className="mode-link">API Reference</a> for full endpoint documentation, request formats, and response schemas.
+
+## Available Tools
+
+| Category | Tools |
+|----------|-------|
+| <a href="/agents/tools-reference#knowledge-graph-tools" className="mode-link">Knowledge Graph</a> | Semantic Search, Fuzzy Lookup, Bulk Fetch, Tag Filter, Node Neighbors |
+| <a href="/agents/tools-reference#code-query-tools" className="mode-link">Code Query</a> | File Structure, Fetch File, Code Analysis |
+| <a href="/agents/tools-reference#web-tools" className="mode-link">Web</a> | Web Search, Page Extractor |
+| <a href="/agents/tools-reference#execution-tools" className="mode-link">Execution</a> | Shell Command |
+| <a href="/agents/tools-reference#task-management-tools" className="mode-link">Task Management</a> | Create Todo, Update Status, Get Todo, List Todos, Add Note, Todo Summary |
+| <a href="/agents/tools-reference#requirement-tools" className="mode-link">Requirements</a> | Add Requirements, Get Requirements |
+
+<Note>
+  During project indexing (`INFERRING` status), embedding-dependent tools are temporarily excluded.
+</Note>


### PR DESCRIPTION
Adds three pre-built agent pages under the Developer > Pre-built Agents section in the sidebar:

- **Codebase Q&A Agent** — new page covering semantic search, API overview, use cases, and available tools
- **CodeGen Agent** — new page covering session-based code generation, diff reviews, and available tools
- **Debugging Agent** — restored and refactored page with 8-step methodology, dual-mode behavior, pre-implementation checklist, multi-agent mode, and linked tools reference

Also updates `docs.json` to add the Pre-built Agents navigation group under Developer.