### PR TITLE
feat: Add contextual options for AI assistants

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -156,6 +156,40 @@
       }
     ]
   },
+  "contextual": {
+    "options": [
+      {
+        "title": "Ask ChatGPT",
+        "description": "Ask ChatGPT about this page",
+        "icon": "message",
+        "href": {
+          "base": "https://chatgpt.com/",
+          "query": [
+            {
+              "key": "q",
+              "value": "Here is some documentation. Answer any questions I have about it: $page"
+            }
+          ]
+        }
+      },
+      {
+        "title": "Ask Claude",
+        "description": "Ask Claude about this page",
+        "icon": "message",
+        "href": {
+          "base": "https://claude.ai/new",
+          "query": [
+            {
+              "key": "q",
+              "value": "Here is some documentation. Answer any questions I have about it: $page"
+            }
+          ]
+        }
+      },
+      "perplexity",
+      "copy"
+    ]
+  },
   "footer": {
     "socials": {
       "x": "https://x.com/potpiedotai",


### PR DESCRIPTION
Adds contextual options for copying, Ask ChatGPT, Ask Claude, and Perplexity using the $page context parameter as requested. This PR isolates the contextual options change from the pre-built agents additions.